### PR TITLE
Fix foreach with resize by temporarily disabling the resize

### DIFF
--- a/tommyds/tommyhashdyn.h
+++ b/tommyds/tommyhashdyn.h
@@ -164,6 +164,7 @@ typedef struct tommy_hashdyn_struct {
 	tommy_count_t bucket_max; /**< Number of buckets. */
 	tommy_count_t bucket_mask; /**< Bit mask to access the buckets. */
 	tommy_count_t count; /**< Number of elements. */
+	tommy_bool_t resize_lock; /**< Lock to make sure the hash isn't resized during a foreach iteration. */
 } tommy_hashdyn;
 
 /**
@@ -245,6 +246,8 @@ void* tommy_hashdyn_remove_existing(tommy_hashdyn* hashdyn, tommy_hashdyn_node* 
  *
  * You can use this function to deallocate all the elements inserted.
  *
+ * Note: it is safe to remove items from the hash table during a foreach, but
+ *       not safe to add them.
  * \code
  * tommy_hashdyn hashdyn;
  *
@@ -292,4 +295,3 @@ tommy_inline tommy_count_t tommy_hashdyn_count(tommy_hashdyn* hashdyn)
 tommy_size_t tommy_hashdyn_memory_usage(tommy_hashdyn* hashdyn);
 
 #endif
-


### PR DESCRIPTION
Using any of the foreach methods on the hashdyn can cause various havoc if the methods want to remove elements as well as perform actions on them. This is because the foreach assumes the hash structure will stay static during the iteration.

This PR fixes that by not performing resizes while a foreach is in progress. That is, the functionality of removing elements from the hash during a foreach (which is a logical use case), is now supported. 

Adding elements during a foreach (a somewhat less logical use case) still isn't supported.

The PR also modifies the tommy_hashdyn_resize method to allow resizing by more than one bit, as if many elements are removed during the foreach we will want to be able to resize by the correct amount, and it is a waste of resources to do so stepwise.
