### PR TITLE
tommytypes: fix tommy_cast on C compilers

### DIFF
--- a/tommyds/tommytypes.h
+++ b/tommyds/tommytypes.h
@@ -74,7 +74,7 @@ typedef tommy_uint32_t tommy_count_t;
 #ifdef __cplusplus
 #define tommy_cast(type, value) static_cast<type>(value)
 #else
-#define tommy_cast(type, value) (value)
+#define tommy_cast(type, value) ((type)value)
 #endif
 
 /******************************************************************************/


### PR DESCRIPTION
Depending on warning options used, tommy_cast() results in
many build warnings if a void * is not used, which happens in
many cases. Suppress these warnings by doing the actual cast.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>