### PR TITLE
Fix segmentation fault in tommy_list_remove_head_not_empty()

### DIFF
--- a/tommyds/tommylist.h
+++ b/tommyds/tommylist.h
@@ -236,7 +236,8 @@ tommy_inline tommy_node* tommy_list_remove_head_not_empty(tommy_list* list)
 	tommy_node* head = tommy_list_head(list);
 
 	/* remove from the "circular" prev list */
-	head->next->prev = head->prev;
+	if (head->next)
+		head->next->prev = head->prev;
 
 	/* remove from the "0 terminated" next list */
 	*list = head->next; /* the new head, in case 0 */


### PR DESCRIPTION
The internal function `tommy_list_remove_head_not_empty()` segfaults when removing an element from a list that only contains one element. This fix avoids the offending NULL pointer access.

Simple testcase:

	/* gcc -g -o testcase testcase.c */
	#include "tommylist.h"
	#include <assert.h>
	
	struct object {
		int value;
		tommy_node node;
	};
	
	int main(int argc, char *argv[]) {
		tommy_list list;
		struct object *obj;
		tommy_node *node;
	
		tommy_list_init(&list);
	
		obj = malloc(sizeof(struct object));
		assert(obj);
		obj->value = 42;
		tommy_list_insert_tail(&list, &obj->node, obj);
		assert(!tommy_list_empty(&list));
	
		node = tommy_list_remove_head_not_empty(&list);
		assert(node);
		obj = node->data;
		assert(obj);
		assert(obj->value == 42);
		free(obj);
		assert(tommy_list_empty(&list));
		return 0;
	}