### PR TITLE
Fix type name in sample code snippet

### DIFF
--- a/tommyds/tommyhashdyn.h
+++ b/tommyds/tommyhashdyn.h
@@ -46,7 +46,7 @@
  * To initialize the hashtable you have to call tommy_hashdyn_init().
  *
  * \code
- * tommy_hashslin hashdyn;
+ * tommy_hashdyn hashdyn;
  *
  * tommy_hashdyn_init(&hashdyn);
  * \endcode

--- a/tommyds/tommyhashlin.h
+++ b/tommyds/tommyhashlin.h
@@ -49,7 +49,7 @@
  * To initialize the hashtable you have to call tommy_hashlin_init().
  *
  * \code
- * tommy_hashslin hashlin;
+ * tommy_hashlin hashlin;
  *
  * tommy_hashlin_init(&hashlin);
  * \endcode

--- a/tommyds/tommyhashtbl.h
+++ b/tommyds/tommyhashtbl.h
@@ -37,7 +37,7 @@
  * the fixed bucket size.
  *
  * \code
- * tommy_hashslin hashtable;
+ * tommy_hashtable hashtable;
  *
  * tommy_hashtable_init(&hashtable, 1024);
  * \endcode


### PR DESCRIPTION
Sample code for the three hash table variants all contain a type name that does not exist. Fix each of them by using the corresponding type name.